### PR TITLE
Fix: export dequant helpers used by the load-time self-test

### DIFF
--- a/engine/quant.js
+++ b/engine/quant.js
@@ -23,7 +23,7 @@ export function quantizeQ4(data) {
   return { qs, scales };
 }
 const scOf = (q, b) => f16ToF32((q.scales[b >> 1] >>> ((b & 1) * 16)) & 0xFFFF);
-function dequantQ4(q, n) {
+export function dequantQ4(q, n) {
   const out = new Float32Array(n);
   for (let b = 0; b < n / 32; b++) for (let j = 0; j < 16; j++) {
     const byte = q.qs[b * 16 + j];
@@ -32,7 +32,7 @@ function dequantQ4(q, n) {
   }
   return out;
 }
-function dequantQ8(q, n) {
+export function dequantQ8(q, n) {
   const out = new Float32Array(n);
   for (let i = 0; i < n; i++) { const v = q.qs[i]; out[i] = scOf(q, (i / 32) | 0) * (v > 127 ? v - 256 : v); }
   return out;

--- a/engine/selftest.js
+++ b/engine/selftest.js
@@ -1,6 +1,6 @@
 // GPU self-test and kernel micro-tests run at load to catch broken drivers early.
 import { DenseEngine } from "./dense.js";
-import { quantizeQ4 } from "./quant.js";
+import { quantizeQ4, dequantQ4, dequantQ8 } from "./quant.js";
 import { quantizeQ8 } from "./gguf.js";
 
 export async function gpuSelfTest(device) {


### PR DESCRIPTION
## Summary
- The module split (092ac5c) moved `dequantQ4`/`dequantQ8` into `engine/quant.js` without exporting them; `engine/selftest.js` still calls both.
- Every device failed at load with `Can't find variable: dequantQ8` (Safari) / `dequantQ8 is not defined` (Chrome), before any weights were fetched. Production has had this since the refactor merge.
- Exports the two helpers and imports them in the self-test. No kernel or engine behaviour changes.

## Test plan
- [x] `gpuSelfTest` and `kernelMicroTests` pass on GB10 under Deno (f32/q8/q4 self-test ok; all 8 micro-tests ok)
- [ ] Load a model in the preview room on Mac Safari and phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkVLt1BijYxEeNWsgihPdN