### PR TITLE
Bench log: standard prompts and a per-PR room benchmark table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 ## Performance (delete if not applicable)
 
 - [ ] Added a row to `docs/bench-log.md` with hardware, commit, and before/after numbers (neutral results included).
+- [ ] Room-tested on real devices: added a row to the "Room benchmarks by PR" table naming the devices and the standard prompt used (`hello`, `meaning` or `japan`).
 
 ## Tested on
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ To run the site locally, serve the repository root with any static server (`npx 
 **Preparing your PR**
 
 - Kernel and engine changes must keep the golden tests passing **bit-exactly**. The speculative decoding path must produce a stream identical to plain decoding (`tests/test_mtp.js`). If a change is intentionally approximate, it needs a switch that defaults to off, and a note in the PR.
-- Performance changes must add a row to [docs/bench-log.md](docs/bench-log.md) with the hardware, commit, and before/after numbers, including neutral results. "Faster" without a number is not reviewable.
+- Performance changes must add a row to [docs/bench-log.md](docs/bench-log.md) with the hardware, commit, and before/after numbers, including neutral results. "Faster" without a number is not reviewable. Room measurements name the devices and one of the standard prompts listed in the bench log, so rows stay comparable across PRs.
 - Protocol changes must keep older peers failing loudly rather than silently (bump the message version).
 - Add or update a test. GPU tests live in `tests/`, unit tests that need no GPU in `tests/unit/`.
 - Keep the diff readable: no reformatting of untouched code, no drive-by renames.

--- a/docs/bench-log.md
+++ b/docs/bench-log.md
@@ -24,3 +24,23 @@ shader-f16 available). Mac = user's MacBook, Chrome, staging site.
 | Sep 2 | GEMM v3 (padded shared tile, 2 blocks/barrier, register prefetch, RT=2×4 cols) | — | | | | 17408×5120×16: 1.54–1.61 ms vs 1.93 (1.21–1.25×); 5120×5120: parity (occupancy: 80 WGs) | | | bank-conflict padding was the only lever that moved it; 4×4 tiles slower (occupancy). Still ~30 GB/s / 1.8 TFLOPS: next try split-K for small dOut, 256-thread WGs, check naga bounds-check cost |
 | Sep 4 | **Prefill GEMM** (roadmap 02): row-stationary Q4_0 GEMM at 16 batch columns, split-K pinned per shape, `_dop` ladder GEMM→b8→b4 | — | 9.0–9.2 (unchanged) | 15.4–15.9 (unchanged, K=5 at 16 cols) | | pass-level 34.6 → **56.7** (1.64×); end-to-end `bench.js` 30.2 → **43.7** (1.45×) | | | ffn_down + ssm_out are Q8_0 ⇒ stay on the GEMV; Q8 variant is the next lever |
 | Sep 4 | Width-dependent rows per workgroup for the b8/b4 twins | — | | 12.8 → 15.4 at 16 cols | | | | | fixed the decode regression the 16-column width introduced; twins byte-identical to native-width kernels (`tests/test_twins.js`) |
+
+## Standard prompts
+
+Room numbers are only comparable when the prompt is the same. Use these, verbatim, and name the prompt in the row. Token counts are for Qwen 3.8 27B's tokenizer, text only; the chat template adds about 9 tokens.
+
+| Name | Tokens | Text |
+|---|---|---|
+| `hello` | 1 | `hello` |
+| `meaning` | 6 | `what is the meaning of life` |
+| `japan` | 160 | `I am planning a two week trip through Japan in late October with my partner. We land in Tokyo, want three days there, then a day trip to Nikko, then the bullet train to Kyoto for four days with a side trip to Nara, then two nights in Osaka, and we fly home from Osaka. We like food markets, old temples, hiking, and small neighborhood bars, and we want to avoid the most crowded tourist spots where we can. Our budget is moderate, around two hundred dollars a day for the two of us not counting hotels. Please give me a day by day itinerary with one main activity each morning and afternoon, a neighborhood to eat dinner in each night, and tell me which days I should buy a rail pass for and whether it is worth it at all.` |
+
+`hello` and `meaning` measure fixed per-request overhead. `japan` is long enough that prefill runs through the 16-column GEMM path for most of its length; use it for any prefill claim. Decode numbers are for the 400-token answer cap; the first answer in a room is slower because the speculation depth starts conservative, so report the second answer or later.
+
+## Room benchmarks by PR (real devices)
+
+One row per merged PR that changes speed, measured in the room on real devices, before and after. "Before" is production (`main`) on the same day; "after" is the PR's preview URL. Prefill is the seconds the status line reports; decode is the tok/s in the answer footer.
+
+| Date | PR | Devices | Prompt | Prefill before → after | Decode before → after | Notes |
+|---|---|---|---|---|---|---|
+| Sep 4 | #29 prefill GEMM | MacBook (Chrome, Metal) 62 layers + embed/head, iPhone 2 layers | `japan` | 13.8 s → **8.5 s** (1.62×) | 7.3 → 7.7 tok/s (unchanged, within noise) | first answer in each room; both runs hit the 512-token context overflow (#31) after ~300 generated tokens, which does not affect the prefill number |


### PR DESCRIPTION
## What
Makes room speed numbers comparable across PRs.
- `docs/bench-log.md`: a **Standard prompts** section (`hello` 1 tok, `meaning` 6 tok, `japan` 160 tok, exact texts) and a **Room benchmarks by PR** table (date, PR, devices, prompt, prefill and decode before → after).
- First row: #29 prefill GEMM on the Mac + iPhone room, `japan` prompt, prefill 13.8 s → 8.5 s (1.62×), decode unchanged.
- PR template and CONTRIBUTING: perf PRs record the devices and the standard prompt they were tested with.

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkVLt1BijYxEeNWsgihPdN