### PR TITLE
Stop generation at the context window; context 2048 (fixes #31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 local-server/
 models/
 presentation/
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to SwarmLLM. Format follows [Keep a Changelog](https://keepa
 - f16 block scales end to end; `unpack4x` dequantization with runtime probe.
 
 ### Fixed
+- Generation no longer runs past the context window (#31): the room stops before the KV cache would overflow and says "stopped: context full", refuses prompts that leave no room for an answer, and the context is 2048 tokens (was 512). Cache size does not change logits (`tests/test_ctx.js`, bit-identical).
 - **`f32ToF16` dropped the rounding carry**, silently halving ~0.03% of all values (e.g. -1.9999911 to -1.0): about 1.4 corrupted numbers per 5,120-float activation frame on every hop of a split room, plus occasional halved Q4/Q8 block scales. The carry now propagates into the exponent; all 65,536 representable f16 values round-trip exactly.
 - Tall matvec dispatches over 65,535 workgroups (the LM head at 2 rows per workgroup) were silently dropped; all matvecs now dispatch in 2-D.
 - Draft depth selection by lap time could lock a Mac-hosted room at maximum depth (1.5 tok/s); replaced by throughput-based selection.

--- a/room.js
+++ b/room.js
@@ -9,7 +9,7 @@ import { Qwen35Engine } from "./engine/qwen35.js";
 import { WIRE_F16, badF32, f32ToB64, packF16, unpackF16, asU16, packWire, unpackWire, asF32, b64ToF32 } from "./room/wire.js";
 import { esc, md } from "./room/markdown.js";
 import { aiSample } from "./room/sampling.js";
-import { MODELS, NEED_GB, MAX_SEQ } from "./room/models.js";
+import { MODELS, NEED_GB, MAX_SEQ, MAX_NEW, MIN_ROOM } from "./room/models.js";
 
 const $ = (id) => document.getElementById(id);
 function toast(text) {
@@ -906,6 +906,11 @@ async function aiGenerate(textArg, who) {
   aiStatus(`prefill: ${ids.length} tokens…`);
 
   try {
+    // the prompt must fit the context with room for an answer; never silently truncate
+    if (ids.length > MAX_SEQ - MIN_ROOM)
+      throw new Error(`prompt is ${ids.length} tokens; this room's context is ${MAX_SEQ} tokens and an answer needs at least ${MIN_ROOM}. Shorten the prompt.`);
+    const maxNew = Math.min(MAX_NEW, MAX_SEQ - ids.length);   // answer cap for this prompt
+    let capped = false;   // set when generation stops because the context filled up
     let logits = null;
     const tPre = performance.now();
     if (!ai.chain.length && ai.engine.prefillTokens && ids.length > 1) {
@@ -1002,32 +1007,41 @@ async function aiGenerate(textArg, who) {
         return best;
       };
       let next = aiSample(logits), done = false;
-      while (!done && count < 400) {
-        const K = pickK(), tStep = performance.now();
+      while (!done && count < maxNew) {
+        // a speculative step touches positions pos .. pos+K (K drafts verified in one pass) and
+        // drafts one more; shrink K near the end of the context and stop before it overflows
+        let K = pickK();
+        const roomLeft = MAX_SEQ - ai.engine.pos - 2;
+        if (roomLeft < 1) { capped = true; break; }
+        K = Math.min(K, roomLeft, maxNew - count + 1);
+        const tStep = performance.now();
         const toks = await ai.engine.specStep(next, aiSample, K, spec);
         const tps = toks.length / ((performance.now() - tStep) / 1000);
         kc.ema[K] = kc.n[K] ? 0.6 * kc.ema[K] + 0.4 * tps : tps;
         kc.n[K] = (kc.n[K] || 0) + 1; kc.used[K] = (kc.used[K] || 0) + toks.length;
         for (const tk of toks) {
           if (tk === imEnd || tk === eot) { done = true; break; }
+          if (count >= maxNew) { done = true; capped = maxNew < MAX_NEW; break; }
           emit(tk);
         }
         next = toks[toks.length - 1];
       }
+      if (!done && count >= maxNew) capped = maxNew < MAX_NEW;
       ai.pos = ai.engine.pos;
       const st = ai.engine.mtp.stats;
       if (st.drafts) crumb(`spec: ${st.accepted}/${st.drafts} drafts accepted${ai.lapMs ? ` · lap ${Math.round(ai.lapMs)}ms` : ""}`
         + (ai.chain.length ? ` · K tok/s ${kc.cand.map((k) => `${k}:${kc.ema[k] ? kc.ema[k].toFixed(1) : "-"}`).join(" ")} · tokens by K ${JSON.stringify(kc.used)}` : ""));
     } else {
-      for (let i = 0; i < 400; i++) {
+      for (let i = 0; i < maxNew; i++) {
         const next = aiSample(logits);
         if (next === imEnd || next === eot) { await aiPipeToken(next, false); break; }
         emit(next);
+        if (ai.pos >= MAX_SEQ - 1) { capped = true; break; }   // no position left for another token
         logits = await aiPipeToken(next);
       }
     }
     const secs = (performance.now() - t0) / 1000;
-    const stats = `${count} tok · ${(count / secs).toFixed(1)} tok/s · ${ai.chain.length + 1} devices`;
+    const stats = `${count} tok · ${(count / secs).toFixed(1)} tok/s · ${ai.chain.length + 1} devices${capped ? ` · stopped: context full (${MAX_SEQ} tokens)` : ""}`;
     chatBotEnd(reply, stats);
     broadcastAll({ t: "ai-gendone", stats });
     mascot("Done. Anyone in the room can ask the next one.");

--- a/room/models.js
+++ b/room/models.js
@@ -23,4 +23,9 @@ export const MODELS = {
     tok: "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/resolve/main/tokenizer.json" },
 };
 
-export const MAX_SEQ = 512;
+// Context window per room, in tokens: prompt + answer. Each full-attention layer keeps K and V
+// for this many positions (4 KB per position each for the 27B, so 16 MiB per attention layer at
+// 2048); the kernels only use it as a stride. Generation stops before the cache would overflow.
+export const MAX_SEQ = 2048;
+export const MAX_NEW = 400;    // longest answer, tokens
+export const MIN_ROOM = 32;    // a prompt must leave at least this many tokens for the answer

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,7 +5,7 @@ set -uo pipefail
 cd "$(dirname "$0")"
 D="deno run --unstable-webgpu --allow-read --allow-env"
 quick=(test_qwen.js test_smollm.js test_stream.js test_batch.js test_reset.js test_qwen_split.js test_qwen_stream.js test_batch_split.js)
-q38=(test_q38.js test_batch_q38.js test_mtp.js test_b4.js test_twins.js test_gemm.js test_q38_split.js test_mtp_split.js)
+q38=(test_q38.js test_batch_q38.js test_mtp.js test_b4.js test_twins.js test_gemm.js test_q38_split.js test_mtp_split.js test_ctx.js)
 case "${1:-quick}" in quick) list=("${quick[@]}");; q38) list=("${q38[@]}");; all) list=("${quick[@]}" "${q38[@]}");; *) echo "unknown suite"; exit 2;; esac
 fail=0
 for t in "${list[@]}"; do

--- a/tests/test_ctx.js
+++ b/tests/test_ctx.js
@@ -1,0 +1,69 @@
+// Context beyond 512 positions on the 27B: (1) a short prompt gives bit-identical logits with
+// maxSeq 512 and 2048 (the cache size is only a stride), (2) a ~640-token prompt prefills and
+// generates past position 512 with no NaN, no GPU error and coherent text.
+import { parseGGUFHeader, qwen35Weights, tokenizerFromGGUF } from "../engine/gguf.js";
+import { makeTokenizer, argmax } from "../engine/engine.js";
+import { Qwen35Engine } from "../engine/qwen35.js";
+
+const dir = new URL(".", import.meta.url).pathname;
+const file = await Deno.open(dir + "../models/q38/model.gguf", { read: true });
+const headBuf = new Uint8Array(16 * 1024 * 1024);
+let got = 0;
+while (got < headBuf.length) { const n = await file.read(headBuf.subarray(got)); if (n === null) break; got += n; }
+const G = parseGGUFHeader(headBuf.buffer);
+const bytesOf = async (info) => {
+  const out = new Uint8Array(info.byteLength);
+  await file.seek(info.byteOffset, Deno.SeekMode.Start);
+  let o = 0;
+  while (o < out.length) { const n = await file.read(out.subarray(o)); if (n === null) break; o += n; }
+  return out;
+};
+const adapter = await navigator.gpu.requestAdapter();
+const device = await adapter.requestDevice({ requiredLimits: { maxBufferSize: adapter.limits.maxBufferSize, maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize } });
+let gpuErrors = 0;
+device.addEventListener?.("uncapturederror", (e) => { gpuErrors++; if (gpuErrors < 4) console.error("GPU ERROR:", e.error?.message?.slice(0, 200)); });
+
+const L = 64;
+console.log("loading all", L, "layers…");
+const tok = makeTokenizer(tokenizerFromGGUF(G.meta));
+// an engine takes ownership of its weight buffers (CPU copies are freed after upload), so each
+// engine loads its own copy
+const mk = async (maxSeq) => {
+  const weights = await qwen35Weights(G, bytesOf, { lo: 0, hi: L, hasEmbed: true, hasHead: true }, () => {});
+  return Qwen35Engine.create({ device, meta: G.meta, weights, layerRange: [0, L], hasEmbed: true, hasHead: true, maxSeq, batchCols: 16, coopRowsB: 1 });
+};
+
+// (1) short prompt, two cache sizes, same logits bit for bit
+const short = tok.encode("The capital of France is");
+const run = async (eng, ids) => { let lg = null; for (const id of ids) lg = await eng.forwardToken(id); return lg; };
+const e512 = await mk(512); const a = Float32Array.from(await run(e512, short));
+try { e512.destroy?.(); } catch {}
+const e2048 = await mk(2048); const b = await run(e2048, short);
+let diff = 0; for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) diff++;
+console.log("short prompt, maxSeq 512 vs 2048: differing logits =", diff);
+if (diff) { console.log("CTX FAIL: cache size changed the logits"); Deno.exit(1); }
+
+// (2) long prompt past the old limit: batched prefill, then greedy generation across position 512
+const para = "I am planning a two week trip through Japan in late October with my partner. We land in Tokyo, want three days there, then a day trip to Nikko, then the bullet train to Kyoto for four days with a side trip to Nara, then two nights in Osaka, and we fly home from Osaka. We like food markets, old temples, hiking, and small neighborhood bars, and we want to avoid the most crowded tourist spots where we can. Our budget is moderate, around two hundred dollars a day for the two of us not counting hotels. ";
+const V = tok.vocab;
+const ids = [V["<|im_start|>"], ...tok.encode("user\n" + para.repeat(4) + "Please give me a day by day itinerary."), V["<|im_end|>"], ...tok.encode("\n"), V["<|im_start|>"], ...tok.encode("assistant\n"), V["<think>"], ...tok.encode("\n\n"), V["</think>"], ...tok.encode("\n\n")];
+console.log("long prompt tokens:", ids.length);
+e2048.reset?.(); e2048.pos = 0;
+let t0 = performance.now();
+await e2048.prefillTokens(ids.slice(0, -1));
+let logits = await e2048.forwardToken(ids[ids.length - 1]);
+console.log("prefill", ((performance.now() - t0) / 1000).toFixed(1), "s, pos now", e2048.pos);
+const gen = []; let nan = false;
+for (let i = 0; i < 48; i++) {
+  if (!Number.isFinite(logits[0]) || !Number.isFinite(logits[logits.length - 1])) { nan = true; break; }
+  const next = argmax(logits); gen.push(next);
+  if (next === V["<|im_end|>"]) break;
+  logits = await e2048.forwardToken(next);
+}
+const text = tok.decode(gen);
+const uniq = new Set(gen).size / Math.max(1, gen.length);
+console.log("generated past pos 512:", JSON.stringify(text));
+console.log(`positions ${ids.length}..${e2048.pos}, NaN: ${nan}, GPU errors: ${gpuErrors}, unique-token ratio ${uniq.toFixed(2)}`);
+const ok = !nan && gpuErrors === 0 && gen.length >= 8 && uniq > 0.5 && !/\(\s*\(\s*\(/.test(text);
+console.log(ok ? "\nCTX PASS ✓ (prefill and decode past the 512-position boundary are clean)" : "\nCTX FAIL");
+Deno.exit(ok ? 0 : 1);


### PR DESCRIPTION
## What
- The answer cap is `min(400, MAX_SEQ - prompt tokens)`. Speculative steps shrink K near the end of the window and stop before `pos + K + 1` would exceed it; the plain loop stops one position short. The answer footer then says `stopped: context full (2048 tokens)`.
- A prompt that leaves fewer than 32 tokens for the answer is refused with a message instead of being silently truncated.
- `MAX_SEQ` 512 → 2048. Cost: 16 MiB per full-attention layer for the 27B (K and V, 4 KiB per position each). The kernels use `maxSeq` only as a stride.

## Verification
- `tests/test_ctx.js` (added to the q38 suite): on the 27B, `maxSeq` 512 and 2048 produce bit-identical logits on a short prompt (0 of 248,320 differ); a 473-token prompt prefills through the batched path and greedy decoding crosses position 512 with no NaN, no GPU error, unique-token ratio 0.81, coherent text.
- Emulator on the GB10, 3 devices, 27B, `japan` prompt, two 400-token answers: **0 room-log errors** (yesterday's run on main: 1,741 `Copy range … does not fit` lines), 9.6 tok/s, prefill 4.2–4.5 s.

Fixes #31. Multi-turn (the other half of roadmap #13) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkVLt1BijYxEeNWsgihPdN