### PR TITLE
Site: GitHub link on the landing page and the room

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
   .spacer { flex: 1; }
   .navlink { font-family: var(--mono); font-size: 12px; color: var(--muted); text-decoration: none; margin-right: 26px; transition: color 0.2s; }
   .navlink:hover { color: var(--ink); }
+  .gh { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 12px; color: var(--muted); text-decoration: none; margin-right: 22px; transition: color 0.2s; }
+  .gh:hover { color: var(--ink); }
+  .gh svg { display: block; }
 
   .cta {
     display: inline-flex; align-items: center; gap: 10px;
@@ -245,6 +248,7 @@
     .cta { padding: 13px 24px; font-size: 13px; }
     #strip { font-size: 9.5px; padding: 14px 24px; }
     .navlink { display: none; }
+    .gh .gh-label { display: none; }
     .how-grid { grid-template-columns: 1fr; gap: 36px; }
     .how-left { position: static; }
   }
@@ -274,6 +278,7 @@
   <a class="wordmark ri" href="/">swarm<em>LLM</em></a>
   <div class="spacer"></div>
   <a class="navlink ri d1" href="#how">what is this?</a>
+  <a class="gh ri d1" href="https://github.com/Nehanth/swarmllm" target="_blank" rel="noopener" aria-label="SwarmLLM on GitHub"><svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-label">github</span></a>
   <a class="cta ri d1" href="/room">start a swarm <span class="arrow">→</span></a>
 </nav>
 
@@ -325,6 +330,7 @@
 <footer>
   <span>swarm<b style="color:var(--accent)">LLM</b> · peer-to-peer inference in the browser</span>
   <div class="spacer"></div>
+  <a class="gh" href="https://github.com/Nehanth/swarmllm" target="_blank" rel="noopener" aria-label="SwarmLLM on GitHub"><svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-label">source on GitHub · MIT</span></a>
 </footer>
 
 <script>

--- a/p2p.html
+++ b/p2p.html
@@ -63,6 +63,8 @@
     transition: all 0.25s;
   }
   #room-badge:hover { background: var(--accent); }
+  #gh-link { display: inline-flex; align-items: center; color: var(--muted); margin-left: 14px; transition: color 0.2s; }
+  #gh-link:hover { color: var(--ink); }
 
   button, input, select {
     background: var(--panel); color: var(--text);
@@ -321,6 +323,7 @@
   <div class="tagline">swarm room</div>
   <div class="spacer"></div>
   <div id="room-badge" title="Click to copy room code"></div>
+  <a id="gh-link" href="https://github.com/Nehanth/swarmllm" target="_blank" rel="noopener" aria-label="SwarmLLM on GitHub" title="source on GitHub"><svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></a>
 </header>
 
 <div id="join-screen">


### PR DESCRIPTION
GitHub mark plus link to the repo in the landing nav (icon only on phones), the footer (with the licence), and the room header. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkVLt1BijYxEeNWsgihPdN