### PR TITLE
Emit the first answer token on the speculative path

### DIFF
--- a/room.js
+++ b/room.js
@@ -1077,7 +1077,11 @@ async function aiGenerate(textArg, who) {
         if (kc.step % 16 === 0) { const alt = kc.cand.filter((k) => k !== best); return alt[(kc.step / 16) % alt.length | 0]; }
         return best;
       };
+      // the first answer token is sampled here; specStep treats it as already chosen for this
+      // position and returns only the tokens after it, so it has to be emitted (or end the
+      // answer) before the loop, or the reply starts one word late
       let next = aiSample(logits), done = false;
+      if (next === imEnd || next === eot) done = true; else emit(next);
       while (!done && count < maxNew) {
         // a speculative step touches positions pos .. pos+K (K drafts verified in one pass) and
         // drafts one more; shrink K near the end of the context and stop before it overflows

--- a/tests/e2e/room.mjs
+++ b/tests/e2e/room.mjs
@@ -135,7 +135,7 @@ try {
     await tabs.host.fill("#ai-prompt", PROMPT); await tabs.host.click("#ai-send");
     await tabs.host.waitForFunction(() => /^ready — prefill|^generation failed/.test(document.getElementById("ai-status").textContent), null, { timeout: 300000 });
     const st = await tabs.host.textContent("#ai-status"); log("round", r, st);
-    const reply = await tabs.host.evaluate(() => { const b = document.querySelectorAll("#chat-log .bubble"); return (b[b.length - 1]?.textContent || "").slice(0, 240); });
+    const reply = await tabs.host.evaluate(() => { const b = document.querySelectorAll(".m.bot .bubble"); return (b[b.length - 1]?.textContent || "").slice(0, 240); });
     results.push({ status: st, reply });
     await tabs.host.waitForTimeout(1000);
   }


### PR DESCRIPTION
Every 27B answer started one word late: the first sampled token was passed to `specStep` as the already-chosen token for its position and never emitted. The plain path (small models) emits it in its loop, so only the speculative path was affected. Verified in the emulator on the 27B: replies begin "Here is the Python code for the Two Sum problem…" instead of "'s…".

Also fixes the emulator's reply capture (wrong selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkVLt1BijYxEeNWsgihPdN