### PR TITLE
Deploy: swarmllm.ai/try/<branch>/room tests a branch with the production weight cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to SwarmLLM. Format follows [Keep a Changelog](https://keepa
 ## [Unreleased]
 
 ### Added
+- `swarmllm.ai/try/<branch>/room` serves a branch's preview deployment under the production origin, so it uses the weights already cached there instead of downloading the model again.
 - Room topology is linear, not a mesh: every device keeps one link to the host; chain neighbours connect only when the layers are dealt (`ensureLink`). A 64-device room opens 126 links instead of 2,016. Workers draw the device list from the host's roster. `?signal=host:port` points the room at a self-hosted PeerServer.
 - Room emulator (`npm run e2e`): `--devices N --phones K`, local PeerServer, 27B from local disk, room-log error capture, fail-fast on load errors. 16 devices on the 27B verified on GB10.
 - Hidden-state wire (`room/transport.js`): activations travel on a dedicated data channel as ≤4.6 KB slices, striped over several peer connections (`?wire=stripeN`, default 4; `?wire=off` to disable). On a 100 ms link a token's hidden state now crosses a hop in 51 ms instead of 152, and a depth-5 verify block in 52 ms instead of 355 (docs/bench-log.md, transport section). Bytes only, output unchanged.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -30,6 +30,7 @@ Model files live in `models/` (git-ignored). The 27B loads in ~2 minutes; plan r
 - Profile by skipping kernel families (`benchmarks/bench_breakdown.js`); timestamp queries cost 3× just by being on.
 - Vercel refuses deploys whose commits have an email that isn't on GitHub; `git config user.email` must match.
 - The room page is served at `/room`; `curl` the alias's `/room`, not `/p2p.html`, to verify a deploy.
+- Test a branch on the production origin so it shares the cached weights: `swarmllm.ai/try/<branch-slug>/room` (slug = the branch name with `/` as `-`, e.g. `feat/redeal` → `feat-redeal`). `vercel.json` rewrites `/try/:branch/*` to that branch's preview deployment; the Cache API is per origin, so a preview URL of its own would download the model again. Links inside the pages are relative for this reason.
 
 ## Layout
 `engine/engine.js` is a barrel; implementation is in `engine/{dense,qwen35,gguf,tokenizer,sampling,quant,autotune,selftest,safetensors}.js` and `engine/wgsl/*.js`. Tests in `tests/` (goldens in `tests/golden`, CPU references in `tests/reference`, no-GPU tests in `tests/unit`). Benchmarks in `benchmarks/`. Docs in `docs/`.

--- a/index.html
+++ b/index.html
@@ -268,18 +268,18 @@
     <p>SwarmLLM splits the model across every device in a room: each one downloads just its slice, and every word of the answer takes a lightning lap through all of them before it appears on every screen at once.</p>
     <p>No install. No accounts. No servers. Your words never leave the room.</p>
     <div class="modal-row">
-      <a class="cta" href="/room">start a swarm <span class="arrow">→</span></a>
+      <a class="cta" href="room">start a swarm <span class="arrow">→</span></a>
       <a id="modal-more" href="#how">read the full story ↓</a>
     </div>
   </div>
 </div>
 
 <nav id="nav">
-  <a class="wordmark ri" href="/">swarm<em>LLM</em></a>
+  <a class="wordmark ri" href="./">swarm<em>LLM</em></a>
   <div class="spacer"></div>
   <a class="navlink ri d1" href="#how">what is this?</a>
   <a class="gh ri d1" href="https://github.com/Nehanth/swarmllm" target="_blank" rel="noopener" aria-label="SwarmLLM on GitHub"><svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-label">github</span></a>
-  <a class="cta ri d1" href="/room">start a swarm <span class="arrow">→</span></a>
+  <a class="cta ri d1" href="room">start a swarm <span class="arrow">→</span></a>
 </nav>
 
 <div id="hero">
@@ -287,7 +287,7 @@
     <div class="kicker ri">MESH INFERENCE</div>
     <h1 class="ri d1">Your phone <span class="dim">can't run</span><br>Qwen 3.8<br><span class="acc">Your room can.</span></h1>
     <p class="sub ri d2">Phones, laptops, friends' PCs: <b>one room code</b> away from becoming a single machine. Each holds a slice of the model; together they run the whole thing. Nothing to install.</p>
-    <a class="cta ri d3" href="/room">start a swarm <span class="arrow">→</span></a>
+    <a class="cta ri d3" href="room">start a swarm <span class="arrow">→</span></a>
   </div>
   <div id="strip" class="ri d3">
     <span>no servers</span><span class="sep">·</span>
@@ -323,7 +323,7 @@
 
   <div class="endcta rv">
     <div class="big">Your devices are already a <em>supercomputer</em>.<br>Introduce them.</div>
-    <a class="cta" href="/room">start a swarm <span class="arrow">→</span></a>
+    <a class="cta" href="room">start a swarm <span class="arrow">→</span></a>
   </div>
 </main>
 

--- a/p2p.html
+++ b/p2p.html
@@ -323,7 +323,7 @@
 <body>
 
 <header>
-  <div class="logo"><a href="/">swarm<span>LLM</span></a></div>
+  <div class="logo"><a href="./">swarm<span>LLM</span></a></div>
   <div class="tagline">swarm room</div>
   <div class="spacer"></div>
   <div id="room-badge" title="Click to copy room code"></div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,25 @@
 {
   "framework": null,
   "trailingSlash": false,
-  "rewrites": [{ "source": "/room", "destination": "/p2p.html" }],
-  "redirects": [{ "source": "/p2p.html", "destination": "/room", "permanent": false }]
+  "rewrites": [
+    {
+      "source": "/try/:branch/:path*",
+      "destination": "https://swarmllm-git-:branch-nehanths-projects.vercel.app/:path*"
+    },
+    {
+      "source": "/try/:branch",
+      "destination": "https://swarmllm-git-:branch-nehanths-projects.vercel.app/"
+    },
+    {
+      "source": "/room",
+      "destination": "/p2p.html"
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/p2p.html",
+      "destination": "/room",
+      "permanent": false
+    }
+  ]
 }


### PR DESCRIPTION
The Cache API is per origin, so a branch preview at `swarmllm-git-<branch>-…vercel.app` cannot see the 16 GB `swarmllm.ai` already cached. This adds a rewrite so `swarmllm.ai/try/<branch-slug>/room` serves that branch's preview deployment under the production origin: same origin, same cache, no re-download.

- `vercel.json`: `/try/:branch/:path*` → `https://swarmllm-git-:branch-nehanths-projects.vercel.app/:path*`
- `index.html` / `p2p.html`: the "start a swarm" and wordmark links are relative, so the landing page under `/try/x/` links into the preview rather than production
- note in `docs/agents.md`, CHANGELOG

Slug = branch name with `/` as `-` (`feat/redeal` → `feat-redeal`). Verified on this branch's own preview: `…/try/feat-redeal/room` serves the re-deal branch's page (the rule works on any deployment, production just makes the cache the shared one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)